### PR TITLE
Fix set_mini_server

### DIFF
--- a/speedtest.py
+++ b/speedtest.py
@@ -920,17 +920,19 @@ class Speedtest(object):
             url = server
 
         host, port = urlparts[1].split(":")
-        self.servers = [
-            {
-                "sponsor": "Speedtest Mini",
-                "name": urlparts[1],
-                "host": (host, int(port)),
-                "d": 0,
-                "url": "%s/speedtest/upload.php" % (url.rstrip("/"),),
-                "latency": 0,
-                "id": 0,
-            }
-        ]
+        self.servers = {
+            0: [
+                {
+                    "sponsor": "Speedtest Mini",
+                    "name": urlparts[1],
+                    "host": (host, int(port)),
+                    "d": 0,
+                    "url": "%s/speedtest/upload.php" % (url.rstrip("/"),),
+                    "latency": 0,
+                    "id": 0,
+                }
+            ]
+        }
 
         return self.servers
 


### PR DESCRIPTION
Other parts of the code expect the self.servers list to look something like {someInt: [{...hostInfo}]}. This PR makes the set_mini_server code set the servers dict to match the expected format.